### PR TITLE
Add missing permissions

### DIFF
--- a/me.proton.Pass.yml
+++ b/me.proton.Pass.yml
@@ -10,6 +10,8 @@ finish-args:
   - --share=network
   - --socket=wayland
   - --socket=fallback-x11
+  - --socket=system-bus
+  - --device=dri
   - --talk-name=org.freedesktop.secrets
   - --env=USE_WAYLAND=1
   - --env=XCURSOR_PATH=~/.icons:/app/share/icons:/icons:/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
Add missing permissions for D-Bus system bus and GPU accereration. Otherwise the application does not open and throws errors about missing files.