### PR TITLE
Add devices=all permission

### DIFF
--- a/me.proton.Pass.yml
+++ b/me.proton.Pass.yml
@@ -10,7 +10,7 @@ finish-args:
   - --share=network
   - --socket=wayland
   - --socket=fallback-x11
-  - --device=dri
+  - --device=all
   - --talk-name=org.freedesktop.secrets
   - --env=USE_WAYLAND=1
   - --env=XCURSOR_PATH=~/.icons:/app/share/icons:/icons:/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
The app has `dri` permissions at the moment for GPU access.

`all` implies `dri` , additionally `all` is needed for authentication with hardware keys (e.g. YubiKey) to work.