### PR TITLE
remove org.freedesktop.secrets dbus access

### DIFF
--- a/me.proton.Pass.yml
+++ b/me.proton.Pass.yml
@@ -11,7 +11,6 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --device=all
-  - --talk-name=org.freedesktop.secrets
   # Tray icon
   - --talk-name=org.kde.StatusNotifierWatcher
   - --env=ELECTRON_OZONE_PLATFORM_HINT=auto


### PR DESCRIPTION
According to https://github.com/flathub/me.proton.Pass/issues/33#issue-2690362673, with the submodules libsecret, it should use the portal instead.