### PR TITLE
Fix Tray Icon not Found

### DIFF
--- a/me.proton.Pass.yml
+++ b/me.proton.Pass.yml
@@ -102,7 +102,7 @@ modules:
       - type: script
         dest-filename: start-proton-pass.sh
         commands:
-          - exec zypak-wrapper "/app/proton-pass/Proton Pass" "$@"
+          - env TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-me.proton.Pass}" zypak-wrapper "/app/proton-pass/Proton Pass" "$@"
 
       - type: file
         path: me.proton.Pass.metainfo.xml


### PR DESCRIPTION
This is a little workaround required for the tray icon to properly display in Electron apps. The same can be found across various Flatpak packages like Spotify, Signal, etc. 

Resolves: #29 