### PR TITLE
Fix Linting Issues

### DIFF
--- a/me.proton.Pass.metainfo.xml
+++ b/me.proton.Pass.metainfo.xml
@@ -8,7 +8,6 @@
 
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
-    <developer_name>Proton AG</developer_name>
     <developer id="ch.protonmail">
         <name>Proton AG</name>
     </developer>

--- a/me.proton.Pass.yml
+++ b/me.proton.Pass.yml
@@ -19,7 +19,7 @@ finish-args:
   - --env=XCURSOR_PATH=~/.icons:/app/share/icons:/icons:/run/host/user-share/icons:/run/host/share/icons
 modules:
   - name: dbus-run-session
-    buildsystem: cmake
+    buildsystem: cmake-ninja
     cleanup: ['*']
     sources:
       - type: archive


### PR DESCRIPTION
This just fixes two minor warnings that the linter has for the appstream info and the build process.

Reference:
- https://docs.flathub.org/docs/for-app-authors/linter/#module-module_name-buildsystem-is-plain-cmake
- https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#developer-name